### PR TITLE
Add AI section with Mattermost + Serge + ChatGPT4All + Gitpod example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,19 @@
 
 ## Contents
 
-- [Official Resources](#official-resources)
-- [Community Contributions](#community-contributions)
-  - [PHP](#php)
-- [Templates](#templates)
-- [Guides](#guides)
+- [Awesome Gitpod ](#awesome-gitpod-)
+  - [Contents](#contents)
+  - [Official Resources](#official-resources)
+    - [Community Contributions](#community-contributions)
+    - [AI](#ai)
+    - [Go](#go)
+    - [Node.js](#nodejs)
+    - [PHP](#php)
+    - [Phaser.io](#phaserio)
+    - [Ruby/Rails](#rubyrails)
+  - [Templates](#templates)
+  - [Guides](#guides)
+  - [Contribute](#contribute)
 
 ## Official Resources
 
@@ -27,6 +35,10 @@
 - [Community](https://community.gitpod.io)
 
 ### Community Contributions
+
+### AI
+
+- [Mattermost + Serge + ChatGPT4All + Gitpod](https://github.com/mattermost/mattermost-ai-framework)
 
 ### Go
 


### PR DESCRIPTION
Hi all!

This PR adds a link to our [mattermost-ai-framework repository](https://github.com/mattermost/mattermost-ai-framework). Mattermost is open source secure collaboration for technical teams, built in Go/React.

This demo repository can run locally and on Gitpod, which lets the user chat with a local, private LLM. We look forward to continued innovation with Gitpod! 💪